### PR TITLE
✨ some updates :)

### DIFF
--- a/Code/Miscellaneous/FollowPlayer.gd
+++ b/Code/Miscellaneous/FollowPlayer.gd
@@ -1,7 +1,0 @@
-extends Node3D
-@export var Player:CharacterBody3D;
-@export var Camera:Camera3D;
-func _physics_process(_delta):
-    position = Player.position;
-    if(Input.is_action_just_pressed("right_mouse")):
-        rotation_degrees.y += 45;

--- a/Code/Miscellaneous/SimpleCharacterController.gd
+++ b/Code/Miscellaneous/SimpleCharacterController.gd
@@ -5,32 +5,35 @@ extends CharacterBody3D
 var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 func _physics_process(delta):
-    #Get the forward and right vectors of the camera
-    var forward = camera.global_transform.basis.z
-    forward.y = 0
-    var right = camera.global_transform.basis.x
-    right.y = 0
-   
-    #Get the input
-    var input:Vector2 = Input.get_vector("left","right","forwards","backwards")
-    var direction:Vector3 = Vector3(input.x,0,input.y)
+	#Get the forward and right vectors of the camera
+	var forward = camera.global_transform.basis.z
+	forward.y = 0
+	var right = camera.global_transform.basis.x
+	right.y = 0
 
-    #Make direction relative to the camera
-    direction = forward * direction.z + right * direction.x
-    direction = direction.normalized()
+	#Get the input
+	var input:Vector2 = Input.get_vector("left","right","forwards","backwards")
+	var direction:Vector3 = Vector3(input.x,0,input.y)
 
-    if Input.is_action_just_pressed("jump") and is_on_floor():
-        velocity.y += 5
+	#Make direction relative to the camera
+	direction = forward * direction.z + right * direction.x
+	direction = direction.normalized()
 
-    #Set velocity and move
-    velocity = Vector3(
-                    direction.x * speed,
-                    velocity.y - gravity * delta,
-                    direction.z * speed
-                )
+	if Input.is_action_just_pressed("jump") and is_on_floor():
+		velocity.y += 5
 
-    #Jump when space is pressed
+	if(Input.is_action_just_pressed("right_mouse")):
+		rotation_degrees.y += 45;
+
+	#Set velocity and move
+	velocity = Vector3(
+					direction.x * speed,
+					velocity.y - gravity * delta,
+					direction.z * speed
+				)
+
+	#Jump when space is pressed
 
 
-    move_and_slide()     
+	move_and_slide()
 

--- a/Code/Rendering/3DPixelCam.gd
+++ b/Code/Rendering/3DPixelCam.gd
@@ -1,34 +1,21 @@
+class_name Camera3DTexelSnapped
 extends Camera3D
 
-#Resolution is 320x180 with some padding to account for the screen texel error
-const width: int = 428
-const height: int = 242
+var texel_error: Vector2
 
-const orthographic_size: float = 8
-const texel_snap: float = float(height) / orthographic_size
+var _last_rot: Vector3
+var _snap_space: Transform3D
 
-@export var cam_proxy: Node3D
-@export var cam: Node3D
-@export  var render_texture : TextureRect 
 
-var last_rot :Vector3
-var snap_space : Transform3D
-#Create a transform with a 45 degree rotation on the y axis
-func _ready():
-    last_rot = cam_proxy.global_rotation
-    snap_space = cam_proxy.global_transform
-
-func _process(_delta): 
-    if cam_proxy.global_rotation != last_rot: 
-        last_rot = cam_proxy.global_rotation 
-        snap_space = cam_proxy.global_transform
-
-    var snap_space_pos := cam_proxy.global_position * snap_space 
-    var snapped_snap_space_pos: Vector3 = floor(snap_space_pos * texel_snap) / texel_snap
-    cam.global_position = snap_space * snapped_snap_space_pos
-    cam.global_rotation = cam_proxy.global_rotation
-
-    var snap_space_error := snapped_snap_space_pos - snap_space_pos
-    var screen_texel_error := Vector2(snap_space_error.x, -snap_space_error.y) * texel_snap
-    render_texture.position = screen_texel_error
-
+func _process(_delta):
+	if global_rotation != _last_rot:
+		_last_rot = global_rotation
+		_snap_space = global_transform
+	var texel_snap := float(get_viewport().size.y) / size
+	var snap_space_pos := global_position * _snap_space
+	var snapped_snap_space_pos: Vector3 = floor(snap_space_pos * texel_snap) / texel_snap
+	var snap_error := snapped_snap_space_pos - snap_space_pos
+	h_offset = snap_error.x
+	v_offset = snap_error.y
+	# NOTE(david): use error to shift the viewport texture on TextureRect/Sprite3D/etc. for extra smooth
+	texel_error = Vector2(snap_error.x, -snap_error.y) * texel_snap

--- a/Code/Rendering/3DPixelCamDisplay.gd
+++ b/Code/Rendering/3DPixelCamDisplay.gd
@@ -1,0 +1,26 @@
+extends Control
+
+@export var viewport: SubViewport
+@export var pixel_movement := true
+@export var sub_pixel_movement := false
+
+@onready var _display := $Display
+
+
+func _process(_delta):
+	var screen_size := Vector2(get_window().size)
+	var game_size := Vector2(viewport.size - Vector2i(2, 2))
+	var display_scale := screen_size / game_size
+
+	var display_scale_min: float = min(display_scale.x, display_scale.y)
+	_display.scale = Vector2(display_scale_min, display_scale_min)
+
+	size = round(_display.scale * game_size)
+	position = round((screen_size - size) / 2)
+
+	if pixel_movement:
+		var cam := viewport.get_camera_3d() as Camera3DTexelSnapped
+		var pixel_error: Vector2 = cam.texel_error * _display.scale
+		_display.position = -_display.scale + pixel_error
+		if not sub_pixel_movement:
+			_display.position = round(_display.position)

--- a/Code/Shaders/PixelArtUpscale.gdshader
+++ b/Code/Shaders/PixelArtUpscale.gdshader
@@ -1,0 +1,18 @@
+// based on code by t3ssel8r: https://youtu.be/d6tp43wZqps
+// adapted to Godot by denovodavid
+
+shader_type canvas_item;
+render_mode unshaded;
+
+void fragment() {
+	// box filter size in texel units
+	vec2 box_size = clamp(fwidth(UV) / TEXTURE_PIXEL_SIZE, 1e-5, 1);
+	// scale uv by texture size to get texel coordinate
+	vec2 tx = UV / TEXTURE_PIXEL_SIZE - 0.5 * box_size;
+	// compute offset for pixel-sized box filter
+	vec2 tx_offset = smoothstep(vec2(1) - box_size, vec2(1), fract(tx));
+	// compute bilinear sample uv coordinates
+	vec2 uv = (floor(tx) + 0.5 + tx_offset) * TEXTURE_PIXEL_SIZE;
+	// sample the texture
+	COLOR = textureGrad(TEXTURE, uv, dFdx(UV), dFdy(UV));
+}

--- a/PixelCam.tscn
+++ b/PixelCam.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://Code/Rendering/3DPixelCam.gd" id="1_2w0tk"]
 [ext_resource type="Material" uid="uid://c6l6sc656khqv" path="res://Art/ObstacleMaterial.tres" id="1_agp8i"]
 [ext_resource type="Material" uid="uid://f8bwp3dbusxj" path="res://Art/ObstacleMaterial_TriPlanar.tres" id="1_wejfa"]
-[ext_resource type="Script" path="res://Code/Miscellaneous/FollowPlayer.gd" id="4_50dbr"]
+[ext_resource type="Script" path="res://Code/Rendering/3DPixelCamDisplay.gd" id="4_w36h7"]
 [ext_resource type="Script" path="res://Code/Miscellaneous/SimpleCharacterController.gd" id="5_eknrk"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ejss7"]
@@ -40,12 +40,12 @@ height = 4.0
 [sub_resource type="SphereShape3D" id="SphereShape3D_7841g"]
 radius = 2.0
 
-[sub_resource type="ViewportTexture" id="ViewportTexture_30v7u"]
-viewport_path = NodePath("UI/SubViewportContainer/SubViewport")
-
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_dowi3"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_o8o4p"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_x6k7b"]
+viewport_path = NodePath("SubViewport")
 
 [node name="Scene" type="Node3D"]
 
@@ -68,7 +68,6 @@ mesh = SubResource("PlaneMesh_0pvek")
 [node name="StaticBody3D" type="StaticBody3D" parent="Obstacle"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle/StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 shape = SubResource("BoxShape3D_bexqa")
 
 [node name="Obstacle2" type="MeshInstance3D" parent="."]
@@ -80,7 +79,6 @@ skeleton = NodePath(".")
 [node name="StaticBody3D" type="StaticBody3D" parent="Obstacle2"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle2/StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 shape = SubResource("BoxShape3D_pi7k0")
 
 [node name="Obstacle3" type="MeshInstance3D" parent="."]
@@ -92,7 +90,6 @@ skeleton = NodePath(".")
 [node name="StaticBody3D" type="StaticBody3D" parent="Obstacle3"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle3/StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 shape = SubResource("BoxShape3D_70m3s")
 
 [node name="Obstacle4" type="MeshInstance3D" parent="."]
@@ -102,10 +99,8 @@ mesh = SubResource("BoxMesh_0hn03")
 skeleton = NodePath(".")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="Obstacle4"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle4/StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 shape = SubResource("BoxShape3D_70m3s")
 
 [node name="Obstacle5" type="MeshInstance3D" parent="."]
@@ -117,59 +112,19 @@ skeleton = NodePath(".")
 [node name="StaticBody3D" type="StaticBody3D" parent="Obstacle5"]
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Obstacle5/StaticBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 shape = SubResource("SphereShape3D_7841g")
 
-[node name="UI" type="Control" parent="."]
-layout_mode = 3
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="SubViewportContainer" type="SubViewportContainer" parent="UI"]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="SubViewport" type="SubViewport" parent="UI/SubViewportContainer"]
-handle_input_locally = false
-size = Vector2i(428, 242)
-render_target_update_mode = 4
-
-[node name="Camera3D" type="Camera3D" parent="UI/SubViewportContainer/SubViewport" node_paths=PackedStringArray("cam_proxy", "cam", "render_texture")]
-transform = Transform3D(0.707107, -0.316614, 0.632263, 0, 0.894154, 0.447759, -0.707107, -0.316614, 0.632263, 0, 6, 7)
-projection = 1
-current = true
-size = 8.0
-far = 100.0
-script = ExtResource("1_2w0tk")
-cam_proxy = NodePath("../../../../CameraProxyRoot/CameraProxy")
-cam = NodePath(".")
-render_texture = NodePath("../../../RenderTexture")
-
-[node name="RenderTexture" type="TextureRect" parent="UI"]
-texture_filter = 1
-texture_repeat = 1
-layout_mode = 0
-offset_right = 429.0
-offset_bottom = 242.0
-texture = SubResource("ViewportTexture_30v7u")
-
-[node name="CameraProxyRoot" type="Node3D" parent="." node_paths=PackedStringArray("Player")]
-transform = Transform3D(1, 0, 2.98023e-08, 0, 1, 0, 2.98023e-08, 0, 1, -1.49012e-07, -4.76837e-07, -5)
-script = ExtResource("4_50dbr")
-Player = NodePath("../Player")
-
-[node name="CameraProxy" type="Node3D" parent="CameraProxyRoot"]
-transform = Transform3D(0.707107, -0.316613, 0.632262, 0, 0.894154, 0.447759, -0.707107, -0.316613, 0.632262, 9, 9, 9)
-
 [node name="Player" type="CharacterBody3D" parent="." node_paths=PackedStringArray("camera")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -5)
+transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 0, 0, -5)
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
 script = ExtResource("5_eknrk")
-camera = NodePath("../UI/SubViewportContainer/SubViewport/Camera3D")
+camera = NodePath("../SubViewport/Camera3D")
+
+[node name="CameraProxy" type="RemoteTransform3D" parent="Player"]
+transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 7, 10)
+remote_path = NodePath("../../SubViewport/Camera3D")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Player"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
@@ -178,3 +133,28 @@ mesh = SubResource("CapsuleMesh_dowi3")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Player"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("CapsuleShape3D_o8o4p")
+
+[node name="SubViewport" type="SubViewport" parent="."]
+handle_input_locally = false
+size = Vector2i(322, 182)
+render_target_update_mode = 4
+
+[node name="Camera3D" type="Camera3D" parent="SubViewport"]
+transform = Transform3D(0.707107, -0.353554, 0.612372, 0, 0.866025, 0.5, -0.707107, -0.353554, 0.612372, 7.07107, 7, 2.07107)
+projection = 1
+current = true
+size = 8.0
+far = 100.0
+script = ExtResource("1_2w0tk")
+
+[node name="UI" type="Control" parent="." node_paths=PackedStringArray("viewport")]
+clip_contents = true
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("4_w36h7")
+viewport = NodePath("../SubViewport")
+
+[node name="Display" type="Sprite2D" parent="UI"]
+texture_filter = 1
+texture = SubResource("ViewportTexture_x6k7b")
+centered = false

--- a/PixelCam.tscn
+++ b/PixelCam.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=19 format=3 uid="uid://b7s2ne36tn76b"]
+[gd_scene load_steps=21 format=3 uid="uid://b7s2ne36tn76b"]
 
 [ext_resource type="Script" path="res://Code/Rendering/3DPixelCam.gd" id="1_2w0tk"]
 [ext_resource type="Material" uid="uid://c6l6sc656khqv" path="res://Art/ObstacleMaterial.tres" id="1_agp8i"]
 [ext_resource type="Material" uid="uid://f8bwp3dbusxj" path="res://Art/ObstacleMaterial_TriPlanar.tres" id="1_wejfa"]
 [ext_resource type="Script" path="res://Code/Rendering/3DPixelCamDisplay.gd" id="4_w36h7"]
 [ext_resource type="Script" path="res://Code/Miscellaneous/SimpleCharacterController.gd" id="5_eknrk"]
+[ext_resource type="Shader" path="res://Code/Shaders/PixelArtUpscale.gdshader" id="6_23jh1"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ejss7"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -43,6 +44,9 @@ radius = 2.0
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_dowi3"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_o8o4p"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_3v7y2"]
+shader = ExtResource("6_23jh1")
 
 [sub_resource type="ViewportTexture" id="ViewportTexture_x6k7b"]
 viewport_path = NodePath("SubViewport")
@@ -155,6 +159,7 @@ script = ExtResource("4_w36h7")
 viewport = NodePath("../SubViewport")
 
 [node name="Display" type="Sprite2D" parent="UI"]
-texture_filter = 1
+texture_filter = 2
+material = SubResource("ShaderMaterial_3v7y2")
 texture = SubResource("ViewportTexture_x6k7b")
 centered = false

--- a/project.godot
+++ b/project.godot
@@ -17,11 +17,8 @@ config/icon="res://icon.svg"
 
 [display]
 
-window/size/viewport_width=426
-window/size/viewport_height=240
-window/size/window_width_override=1280
-window/size/window_height_override=720
-window/stretch/mode="viewport"
+window/size/viewport_width=1280
+window/size/viewport_height=720
 
 [input]
 


### PR DESCRIPTION
Hello,
I found I slightly nicer way of snapping the camera using the camera `h_offset` and `v_offset` variables. This means the script can go directly on the camera without needing an extra node transform.
I also fixed up the display of the viewport texture so that it can do pixel and sub-pixel smoothing, and sizes/positions correctly with the window keeping the same aspect ratio no matter the size.
Hopefully this makes sense. I am calculating the correct game resolution based on the subviewport size, which I set to 320x180 + 2px of padding when shifting the final texture. The viewport texture is now displayed on a Sprite2D, so it can do sub-pixel movement if desired.
There is still an issue with the character having some jitter, I think this is because the camera get's snapped, but the player does not, so it's impossible for the camera to follow something exactly (unless it's also snapped). So you could try snapping the player movement, or I think smoothing out the camera follow will also make it less noticeable.
anyway, enjoy!